### PR TITLE
VITA: limit newlib heap to have enough vm memory

### DIFF
--- a/libretro/core/libretro-core.cpp
+++ b/libretro/core/libretro-core.cpp
@@ -2,6 +2,7 @@
 
 #ifdef VITA
 #define __GNU_VISIBLE 1
+int _newlib_heap_size_user = 287 * 1024 * 1024;
 #endif
 #include "libretro-core.h"
 


### PR DESCRIPTION
Fixes crashes of #18 