### PR TITLE
Flush all audio samples of each frame and send good size of sample to libretro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,18 @@ else ifeq ($(platform), classic_armv8_a35)
 	    LDFLAGS += -static-libgcc -static-libstdc++
 	  endif
 	endif
-else ifeq ($(platform), osx)
-	TARGET := $(TARGET_NAME)_libretro.dylib
-	fpic := -fPIC -mmacosx-version-min=10.6
-	SHARED := -dynamiclib
+else ifeq ($(platform), miyoomini)
+   	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/miyoomini-toolchain/usr/bin/arm-linux-gnueabihf-gcc
+	CXX = /opt/miyoomini-toolchain/usr/bin/arm-linux-gnueabihf-g++
+	AR = /opt/miyoomini-toolchain/usr/bin/arm-linux-gnueabihf-ar
+	fpic := -fPIC
+	LDFLAGS := -lpthread
+	SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T 
+	PLATFORM_DEFINES += -mtune=cortex-a7 -mfpu=neon-vfpv4
+	CFLAGS += $(PLATFORM_DEFINES)
+	HAVE_NEON = 1
+	CPU_FLAGS +=  -marm
 else ifeq ($(platform), android)
 	CC = arm-linux-androideabi-gcc
 	CXX =arm-linux-androideabi-g++
@@ -189,25 +197,7 @@ else ifeq ($(platform), android)
 	fpic := -fPIC
 	LDFLAGS := -lm -llog
 	SHARED :=  -Wl,--fix-cortex-a8 -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
-	PLATFLAGS += -DANDROID -DAND -DANDPORT -DARM_OPT_TEST=1
-else ifeq ($(platform), wii)
-	TARGET := $(TARGET_NAME)_libretro_wii.a
-	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
-	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)   
-	ZLIB_DIR = $(LIBUTILS)/zlib/
-	CFLAGS += -DSDL_BYTEORDER=SDL_BIG_ENDIAN -DMSB_FIRST -DBYTE_ORDER=BIG_ENDIAN  -DBYTE_ORDER=BIG_ENDIAN \
-	-DWIIPORT=1 -DHAVE_MEMALIGN -DHAVE_ASPRINTF -I$(ZLIB_DIR) -I$(DEVKITPRO)/libogc/include \
-	-D__powerpc__ -D__POWERPC__ -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__
-	LDFLAGS :=   -lm -lpthread -lc
-	PLATFLAGS += -DWIIPORT
-else ifeq ($(platform), ps3)
-	TARGET := $(TARGET_NAME)_libretro_ps3.a
-	CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
-	AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-	ZLIB_DIR = $(LIBUTILS)/zlib/
-	LDFLAGS :=   -lm -lpthread -lc
-	CFLAGS += -DSDL_BYTEORDER=SDL_BIG_ENDIAN -DMSB_FIRST -DBYTE_ORDER=BIG_ENDIAN  -DBYTE_ORDER=BIG_ENDIAN \
-	-D__CELLOS_LV2 -DPS3PORT=1 -DHAVE_MEMALIGN -DHAVE_ASPRINTF -I$(ZLIB_DIR)  
+	PLATFLAGS += -DANDROID -DAND -DANDPORT -DARM_OPT_TEST=1 
 else
 
 ifeq ($(subplatform), 32)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uae4arm-libretro
 
-Based on old uae4arm version.
+Based on old uae4arm version with psp support.
 
 ## Controls
 

--- a/libretro/core/libretro-core.cpp
+++ b/libretro/core/libretro-core.cpp
@@ -53,6 +53,8 @@ extern void Emu_uninit();
 extern void input_gui(void);
 extern void retro_virtualkb(void);
 
+extern void flush_audio(void);
+
 const char *retro_save_directory;
 const char *retro_system_directory;
 const char *retro_content_directory;
@@ -655,7 +657,9 @@ void retro_set_video_refresh(retro_video_refresh_t cb)
 }
 
 
-void retro_audiocb(signed short int *sound_buffer,int sndbufsize){
+
+void retro_audiocb(signed short int *sound_buffer,int sndbufsize)
+{
 
     if(pauseg==0)
         audio_batch_cb(sound_buffer, sndbufsize);
@@ -718,6 +722,8 @@ void retro_run(void)
    if(pauseg==0)
       if(SHOWKEY )
          retro_virtualkb();
+
+   flush_audio();
 
    video_cb(Retro_Screen,retrow,retroh,retrow<<PIXEL_BYTES);
 

--- a/libretro/core/libretro-core.cpp
+++ b/libretro/core/libretro-core.cpp
@@ -259,7 +259,7 @@ void update_prefs_retrocfg(struct uae_prefs * prefs)
       LOGI("[libretro-uae4arm]: Got model: %s.\n", var.value);
       if (strcmp(var.value, "Auto") == 0)
       {
-         if (strcasestr(RPATH,"aga") != NULL)
+         if ((strcasestr(RPATH,"aga") != NULL) || (strcasestr(RPATH,"a1200") != NULL))
          {
             LOGI("[libretro-uae4arm]: Auto-model -> A1200 selected\n");
             var.value = "A1200";

--- a/libretro/osdep/sound.h
+++ b/libretro/osdep/sound.h
@@ -13,7 +13,7 @@
 #endif
 
 #define SOUND_BUFFERS_COUNT 1
-#define SNDBUFFER_LEN 2048
+#define SNDBUFFER_LEN 256
 
 extern uae_u16 sndbuffer[SOUND_BUFFERS_COUNT][(SNDBUFFER_LEN+32)*DEFAULT_SOUND_CHANNELS];
 extern uae_u16 *sndbufpt;


### PR DESCRIPTION
There has been issue reported lately regarding audio for this core:

https://github.com/Chips-fr/uae4arm-rpi/issues/73
https://github.com/libretro/uae4arm-libretro/issues/23

After some debugging it has been identified that audio samples number where wrong and not always the same for each video frame.
After improving theses points, it has been confirmed that it solve both above issue on vita and a linux handheld.
